### PR TITLE
Changed `&&` to `;` in Powershell command.

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,5 +7,5 @@ Windows one-line installer for zlib library.
 # Usage
 
 ```
-powershell -Command "(New-Object Net.WebClient).DownloadFile('https://raw.githubusercontent.com/horta/zlib.install/master/install.bat', 'install.bat')" && ./install.bat
+powershell -Command "(New-Object Net.WebClient).DownloadFile('https://raw.githubusercontent.com/horta/zlib.install/master/install.bat', 'install.bat')"; ./install.bat
 ```


### PR DESCRIPTION
Using `&&` in the latest version of Powershell throws the following error:
```powershell
> powershell -Command "(New-Object Net.WebClient).DownloadFile('https://raw.githubusercontent.com/horta/zlib.install/master/install.bat', 'install.bat')" && ./install.bat
>>                                                                                                                                          At line:1 char:153
+ ... om/horta/zlib.install/master/install.bat', 'install.bat')" && ./insta ...
+                                                                ~~
The token '&&' is not a valid statement separator in this version.
    + CategoryInfo          : ParserError: (:) [], ParentContainsErrorRecordException
    + FullyQualifiedErrorId : InvalidEndOfLine
```