### PR TITLE
Upgrade to zlib 1.2.12

### DIFF
--- a/install.bat
+++ b/install.bat
@@ -4,7 +4,7 @@ setlocal EnableDelayedExpansion
 set ORIGIN=%cd%
 
 :: Configuration
-set VERSION=1.2.11
+set VERSION=1.2.12
 set VER=%VERSION:.=%
 set URL=https://zlib.net/zlib%VER%.zip
 set CMAKE_VS_PLATFORM_NAME=x64


### PR DESCRIPTION
It looks like zlib 1.2.11 is not longer available as https://zlib.net/zlib1211.zip gives a file not found.

Found when trying to build cbgen https://github.com/limix/cbgen/runs/5771493640?check_suite_focus=true.